### PR TITLE
08 lancet final fixes

### DIFF
--- a/08-lancet.Rmd
+++ b/08-lancet.Rmd
@@ -13,14 +13,9 @@ output:
 
 *Suggested degree: Bachelor*
 
-```{r message=FALSE, warning=FALSE, include=FALSE}
-library(bookdown)
-library(svglite)
-```
-
 ## Introduction
 
-The 2023 report of the Lancet Countdown on health and climate change (@romanello20232023) aims to monitor the evolving impact of climate change on health and the emerging health opportunities of climate action. It is in its eighth iteration and was created by 114 scientists and health practitioners from 52 research institutions and UN agencies from all continents (but Antarctica). While this chapter is based on the 2023 report, there are also regional reports available, such as the 2024 report for Europe (@Van_Daalen2024-ut).
+The 2023 report of the Lancet Countdown on health and climate change (@romanello2023) aims to monitor the evolving impact of climate change on health and the emerging health opportunities of climate action. It is in its eighth iteration and was created by 114 scientists and health practitioners from 52 research institutions and UN agencies from all continents (but Antarctica). While this chapter is based on the 2023 report, there are also regional reports available, such as the 2024 report for Europe (@vandaalen2024).
 
 The current report focuses on 47 indicators, tracking changes based on observed data as well as projections, in the following fields:
 
@@ -34,14 +29,14 @@ The remainder of this chapter provides some background information on climate mo
 
 ## Background
 
-Shared Socioeconomic pathways (SSPs) (@RIAHI2017153) were established by the climate research community in order to make the analysis of future climate impacts, vulnerabilities, adaptation, and mitigation possible. They describe alternative socioeconomic developments regarding their energy, land use, and emissions implications, e.g. more or less renewable energy vs. fossil fuels. The following SSPs are of interest for the rest of this chapter:
+Shared Socioeconomic pathways (SSPs) (@riahi2017) were established by the climate research community in order to make the analysis of future climate impacts, vulnerabilities, adaptation, and mitigation possible. They describe alternative socioeconomic developments regarding their energy, land use, and emissions implications, e.g. more or less renewable energy vs. fossil fuels. The following SSPs are of interest for the rest of this chapter:
 
 #. SSP1: Sustainability (low challenges to mitigation and adaption), corresponding to a 2°C emission scenario
 #. SSP3: Regional Rivalry (high challenges to mitigation and adaptation), corresponding to a 3.7°C emission scenario
 
-These pathways are considered by climate models, e.g. CMIP6 (@gmd-9-1937-2016), in order to describe multiple scenarios for climate projections. Figure \@ref(fig:cmip6strobl) shows CMIP6 simulations for multiple models and all SSPs. In this chapter, we consider SSP1, representing a sustainable path, and SSP3, representing a non-sustainable path, which humanity is following right now.
+These pathways are considered by climate models, e.g. CMIP6 (@eyring2016), in order to describe multiple scenarios for climate projections. Figure \@ref(fig:cmip6strobl) shows CMIP6 simulations for multiple models and all SSPs. In this chapter, we consider SSP1, representing a sustainable path, and SSP3, representing a non-sustainable path, which humanity is following right now.
 
-```{r cmip6strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="CMIP6 climate simulations for SSPs with projections until 2100 (https://www.dkrz.de/en/communication/climate-simulations/cmip6-en/cmip6-acivities-at-dkrz-overview?set\\_language=en; accessed on July 10, 2024)"}
+```{r cmip6strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="CMIP6 climate simulations for SSPs with projections until 2100 (https://www.dkrz.de/en/communication/climate-simulations/cmip6-en/cmip6-acivities-at-dkrz-overview?set\\_language=en; accessed on July 10, 2024)"}
 knitr::include_graphics("work/08-lancet/figures/cmip6.jpg")
 ```
 
@@ -51,17 +46,17 @@ We selected three indicators from the first field (Health hazards, exposures, an
 
 ### Indicator 1.1.2: Exposure of vulnerable populations to heatwaves
 
-Heatwaves have a severe or even life-threatening impact on human health, e.g. high temperatures can cause heat stroke, heat exhaustion, heat syncope, and heat cramps (see, for example, @doi:10.1161/CIRCULATIONAHA.122.061832 or @chambers2020). The following variables (among others) can influence mortality: increased risk for older adults (>65 years of age), low-income countries due to a reduced number of health workers, or pre-existing cardiovascular and chronic respiratory conditions.
+Heatwaves have a severe or even life-threatening impact on human health, e.g. high temperatures can cause heat stroke, heat exhaustion, heat syncope, and heat cramps (see, for example, @alahamad2023 or @chambers2020a). The following variables (among others) can influence mortality: increased risk for older adults (>65 years of age), low-income countries due to a reduced number of health workers, or pre-existing cardiovascular and chronic respiratory conditions.
 
 This indicator tracks the number of heatwave days and the exposure of vulnerable populations (older adults and infants <1 years of age) to heatwaves. A heatwave day is a period of 2 or more days where both the minimum and maximum temperatures are above the 95th percentile of temperatures in 1986-2005.
 
 The following datasets were used for this indicator:
 
-* ERA5 monthly averaged data on single levels (@hersbach2020era5): World-wide weather data on a lat-lon grid of 0.25 degrees from 1940 onwards.
-* ISIMP3b Bias Adjustment dataset (@lange2021isimip3b): A bias adjusted and downscaled version of the output of CMIP6 climate models with projections up to the year 2100.
-* Hybrid gridded demographic data for the world (@Chambers_2020): Demographics data from 1950-2020 with 5-year population bands and a 0.5 degree grid.
+* ERA5 monthly averaged data on single levels (@hersbach2020): World-wide weather data on a lat-lon grid of 0.25 degrees from 1940 onwards.
+* ISIMP3b Bias Adjustment dataset (@lange2021): A bias adjusted and downscaled version of the output of CMIP6 climate models with projections up to the year 2100.
+* Hybrid gridded demographic data for the world (@chambers2020b): Demographics data from 1950-2020 with 5-year population bands and a 0.5 degree grid.
 * 2020 Revision of World Population Prospects (https://population.un.org/wpp/): This dataset contains population estimates as well as projections for 237 countries or areas between 1950 and 2100.
-* A global downscaled age structure dataset for assessing human impacts of climate change (@briggsdaviddownscaled): This dataset contains historic population estimates starting in 1970 and projections considering SSP1 and SSP3 in a 0.5 degree grid.
+* A global downscaled age structure dataset for assessing human impacts of climate change (@briggs2021): This dataset contains historic population estimates starting in 1970 and projections considering SSP1 and SSP3 in a 0.5 degree grid.
 
 Headline Finding:
 
@@ -69,10 +64,10 @@ Headline Finding:
 
 Figures \@ref(fig:heatwaves1infantsstrobl) and \@ref(fig:heatwaves1adultsstrobl) show the increase in the number of heatwave days, comparing the time periods 1986-2005 and 2013-2022, for infants and older adults, respectively. This increase (or decrease for Portugal) per country can be calculated, for example, through ERA5 monthly averaged weather data and the hybrid gridded demographics dataset.
 
-```{r heatwaves1infantsstrobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for infants, comparing the time periods 1986-2005 and 2013-2022."}
+```{r heatwaves1infantsstrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for infants, comparing the time periods 1986-2005 and 2013-2022."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_1.png")
 ```
-```{r heatwaves1adultsstrobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for older adults, comparing the time periods 1986-2005 and 2013-2022."}
+```{r heatwaves1adultsstrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for older adults, comparing the time periods 1986-2005 and 2013-2022."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_2.png")
 ```
 
@@ -80,10 +75,10 @@ The change in the number of heatwave days ranges from approximately -1 in Portug
 
 Similarly, the ISIMP3b Bias Adjustment dataset combined with the global downscaled age structure dataset can be used to project the change in heatwave days up until the year 2100. Figures \@ref(fig:heatwaves2ssp1strobl) and \@ref(fig:heatwaves2ssp3strobl) show the projected change in heatwave days for older adults at mid-century (2041-2060) with baseline period 1995-2014. For example, the increase for Venezuela ranges from approximately 88 (SSP1) to 153 (SSP3) heatwave days per year.
 
-```{r heatwaves2ssp1strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r heatwaves2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_3.png")
 ```
-```{r heatwaves2ssp3strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r heatwaves2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_4.png")
 ```
 
@@ -91,32 +86,32 @@ knitr::include_graphics("work/08-lancet/figures/indicator_1_4.png")
 
 This indicator is tracking days with temperatures exceeding safe levels for humans and heat-related mortality. Only older adults are considered.
 
-Similar datasets are used here as for the previous indicator. However, the difficulty arises due to the fact that safe temperatures may vary across regions (see @Honda2014). 
+Similar datasets are used here as for the previous indicator. However, the difficulty arises due to the fact that safe temperatures may vary across regions (see @honda2014). 
 
 Headline Finding:
 
 "In 2018-2022, people experienced on average 86 days of health-threatening high temperatures annually. 60% of such temperatures were made more than twice as likely to occur by human-caused climate change."
 
-Therefore, @Honda2014 created the notion of an Optimum Temperature (OT), at which the mortality is the lowest. Figure \@ref(fig:mortalityhondastrobl) shows an example for the Tokyo Prefecture and the period 1972-2008. A smoothing spline with six degrees of freedom was used to model the Relative Risk (RR) for mortality and observed daily maximum temperature data. OT represents the daily maximum temperature where RR is the lowest. RR was used here in order to account for different populations of regions and an RR=1.0 is the reference mortality at around OT, i.e. the average number of deaths observed when the daily maximum temperature was within the range of the 75th to the 85th percentile for each year.
+Therefore, @honda2014 created the notion of an Optimum Temperature (OT), at which the mortality is the lowest. Figure \@ref(fig:mortalityhondastrobl) shows an example for the Tokyo Prefecture and the period 1972-2008. A smoothing spline with six degrees of freedom was used to model the Relative Risk (RR) for mortality and observed daily maximum temperature data. OT represents the daily maximum temperature where RR is the lowest. RR was used here in order to account for different populations of regions and an RR=1.0 is the reference mortality at around OT, i.e. the average number of deaths observed when the daily maximum temperature was within the range of the 75th to the 85th percentile for each year.
 
-```{r mortalityhondastrobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="A smoothing spline with six degrees of freedom was used for temperature data from the Tokyo Prefecture and the period 1972-2008, showing the daily maximum temperatures and the Relative Risk (RR) for mortality."}
+```{r mortalityhondastrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="A smoothing spline with six degrees of freedom was used for temperature data from the Tokyo Prefecture and the period 1972-2008, showing the daily maximum temperatures and the Relative Risk (RR) for mortality."}
 knitr::include_graphics("work/08-lancet/figures/121_3.png")
 ```
 
-The shaded area to the right of OT represents temperatures with increased mortality, i.e. daily maximum temperatures above OT are considered as risky for older adults. The average OT percentile of 47 Japanese prefectures was 83.6, which was used to decide which daily maximum temperatures exceeded safe levels for this indicator. In addition, a distributed lag nonlinear model (@Armstrong2006-mv) was used to model the increase in mortality (represented by RR) depending on temperature. This model is considered as a response function, which can be used to calculate the RR and therefore the absolute increase of mortality depending on the observed or projected temperatures.
+The shaded area to the right of OT represents temperatures with increased mortality, i.e. daily maximum temperatures above OT are considered as risky for older adults. The average OT percentile of 47 Japanese prefectures was 83.6, which was used to decide which daily maximum temperatures exceeded safe levels for this indicator. In addition, a distributed lag nonlinear model (@armstrong2006) was used to model the increase in mortality (represented by RR) depending on temperature. This model is considered as a response function, which can be used to calculate the RR and therefore the absolute increase of mortality depending on the observed or projected temperatures.
 
 Figure \@ref(fig:mortality1strobl) shows the increase in the number of days with unsafe temperatures (daily maximum temperatures exceeding OT). This includes the increasing number of days that were made at least twice as likely due to human induced climate change (it is not described how the red line was created).
 
-```{r mortality1strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Average number of days with unsafe temperatures for older adults from 1997 to 2022, including days that are twice as likely due to climate change."}
+```{r mortality1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Average number of days with unsafe temperatures for older adults from 1997 to 2022, including days that are twice as likely due to climate change."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_1.png")
 ```
 
 In addition, Figures \@ref(fig:mortality2ssp1strobl) and \@ref(fig:mortality2ssp3strobl) show the absolute projected increase in heat-related mortality per country for older adults at mid-century (2041-2060) compared to 1995-2014 as baseline, for SSP1 and SSP3, respectively. In both cases there is an increase, although it seems that the two scenarios, SSP1 and SSP3, have been flipped accidentially. In addition, only the absolute increase is shown, i.e. it is obvious that highly populated countries, such as India and China, have a very high increase compared to smaller countries. 
 
-```{r mortality2ssp1strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r mortality2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_4.png")
 ```
-```{r mortality2ssp3strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r mortality2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_5.png")
 ```
 
@@ -124,9 +119,9 @@ The response function is kept constant for these projections, i.e. adaptation is
 
 ### Indicator 1.4: Food insecurity and undernutrition
 
-In 2022, 725 million people faced hunger and in 2021, 3.1 billion people were unable to afford a healthy diet (@noauthor_2023-jt). For example, climate change is undermining crop yields, affecting labour capacity, and threatening food security of marine resources.
+In 2022, 725 million people faced hunger and in 2021, 3.1 billion people were unable to afford a healthy diet (@fao2023). For example, climate change is undermining crop yields, affecting labour capacity, and threatening food security of marine resources.
 
-In addition to the previously mentioned datasets, specifically ERA5 and ISIMP3b, data from the Food and Agriculture Organization Food Insecurity Experience Scale (FIES) (@CAFIERO2018146) was used. This dataset contains survey data from 153 countries and territories during the years 2014, 2015, and 2016. Among others, people were asked for whether they experienced moderate or severe food insecurity within the past 12 months. This was matched with weather data in these peoples specific regions in order to find out whether they experienced heatwaves (as previously defined) or drought months (12-monthly SPEI; only during the growth season of specific crops). In order to make predictions for all other years, including the future, a time-varying panel regression model was used (without further detail). The goal was to predict the percentage of people reporting food insecurity based on heatwaves and drought months experienced within a specific year.
+In addition to the previously mentioned datasets, specifically ERA5 and ISIMP3b, data from the Food and Agriculture Organization Food Insecurity Experience Scale (FIES) (@cafiero2018) was used. This dataset contains survey data from 153 countries and territories during the years 2014, 2015, and 2016. Among others, people were asked for whether they experienced moderate or severe food insecurity within the past 12 months. This was matched with weather data in these peoples specific regions in order to find out whether they experienced heatwaves (as previously defined) or drought months (12-monthly SPEI; only during the growth season of specific crops). In order to make predictions for all other years, including the future, a time-varying panel regression model was used (without further detail). The goal was to predict the percentage of people reporting food insecurity based on heatwaves and drought months experienced within a specific year.
 
 Headline Finding:
 
@@ -134,16 +129,16 @@ Headline Finding:
 
 Figure \@ref(fig:food1strobl) shows world-wide predictions of the change in percentage points (using the previously mentioned model) for heatwaves and drought months for the period 2014-2021. As temperatures, number of heatwave days as well as number of drought months increase, more people are expected to experience severe or moderate food insecurity.
 
-```{r food1strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Impact of extreme weather (heatwaves and droughts) on food insecurity from 2014-2021, based on survey data."}
+```{r food1strobl, cache=FALSE, out.width="700", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Impact of extreme weather (heatwaves and droughts) on food insecurity from 2014-2021, based on survey data."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_1.png")
 ```
 
 Figures \@ref(fig:food2ssp1strobl) and \@ref(fig:food2ssp3strobl) show projections (SSP1 and SSP3, respectively) for the percentage point changes for both kinds of extreme weather combined for mid-century (2014-2060), compared to the baseline 1995-2014. For example for Somalia, this change ranges from 4.02 (SSP1) to 10.32 (SSP3).
 
-```{r food2ssp1strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r food2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_2.png")
 ```
-```{r food2ssp3strobl, cache=FALSE, out.width="100%", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r food2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_3.png")
 ```
 
@@ -155,7 +150,7 @@ The 2023 report of the Lancet Countdown on health and climate change provides a 
 
 We provided detailed descriptions of three main indicators and the modelling techniques used, if mentioned. However, there are a few issues discovered:
 
-* These modelling techniques are typically not described in much detail. Sometimes, as in the case for @Honda2014, some more information is provided in cited articles, but still on a relatively high level.
+* These modelling techniques are typically not described in much detail. Sometimes, as in the case for @honda2014, some more information is provided in cited articles, but still on a relatively high level.
 * The baselines for comparisons or projections vary. It is not clear, nor described, why different baselines are used. For projections, it is obvious that the baseline for CMIP6 projections (1995-2014) was used, without information on why not the one that was previously used for the indicator at hand.
 * In general, the main findings are reported, without going much into detail on how the authors came up with these. In some cases, e.g. indicator 1.1.5, cited articles provide more information, but in other cases, e.g. indicator 1.4, it seems to be mainly the authors own work, without providing details. 
 

--- a/08-lancet.Rmd
+++ b/08-lancet.Rmd
@@ -11,7 +11,7 @@ output:
 
 *Supervisor: Prof. Dr. Helmut Küchenhoff*
 
-*Suggested degree: Bachelor*
+*Degree: Bachelor*
 
 ## Introduction
 
@@ -36,7 +36,7 @@ Shared Socioeconomic pathways (SSPs) (@riahi2017) were established by the climat
 
 These pathways are considered by climate models, e.g. CMIP6 (@eyring2016), in order to describe multiple scenarios for climate projections. Figure \@ref(fig:cmip6strobl) shows CMIP6 simulations for multiple models and all SSPs. In this chapter, we consider SSP1, representing a sustainable path, and SSP3, representing a non-sustainable path, which humanity is following right now.
 
-```{r cmip6strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="CMIP6 climate simulations for SSPs with projections until 2100 (https://www.dkrz.de/en/communication/climate-simulations/cmip6-en/cmip6-acivities-at-dkrz-overview?set\\_language=en; accessed on July 10, 2024)"}
+```{r cmip6strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="CMIP6 climate simulations for SSPs with projections until 2100 (https://www.dkrz.de/en/communication/climate-simulations/cmip6-en/cmip6-acivities-at-dkrz-overview?set\\_language=en; accessed on July 10, 2024)"}
 knitr::include_graphics("work/08-lancet/figures/cmip6.jpg")
 ```
 
@@ -64,10 +64,10 @@ Headline Finding:
 
 Figures \@ref(fig:heatwaves1infantsstrobl) and \@ref(fig:heatwaves1adultsstrobl) show the increase in the number of heatwave days, comparing the time periods 1986-2005 and 2013-2022, for infants and older adults, respectively. This increase (or decrease for Portugal) per country can be calculated, for example, through ERA5 monthly averaged weather data and the hybrid gridded demographics dataset.
 
-```{r heatwaves1infantsstrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for infants, comparing the time periods 1986-2005 and 2013-2022."}
+```{r heatwaves1infantsstrobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for infants, comparing the time periods 1986-2005 and 2013-2022."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_1.png")
 ```
-```{r heatwaves1adultsstrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for older adults, comparing the time periods 1986-2005 and 2013-2022."}
+```{r heatwaves1adultsstrobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Change in number of heatwave days per country for older adults, comparing the time periods 1986-2005 and 2013-2022."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_2.png")
 ```
 
@@ -75,10 +75,10 @@ The change in the number of heatwave days ranges from approximately -1 in Portug
 
 Similarly, the ISIMP3b Bias Adjustment dataset combined with the global downscaled age structure dataset can be used to project the change in heatwave days up until the year 2100. Figures \@ref(fig:heatwaves2ssp1strobl) and \@ref(fig:heatwaves2ssp3strobl) show the projected change in heatwave days for older adults at mid-century (2041-2060) with baseline period 1995-2014. For example, the increase for Venezuela ranges from approximately 88 (SSP1) to 153 (SSP3) heatwave days per year.
 
-```{r heatwaves2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r heatwaves2ssp1strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_3.png")
 ```
-```{r heatwaves2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r heatwaves2ssp3strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the change in number of heatwave days for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_1_4.png")
 ```
 
@@ -94,7 +94,7 @@ Headline Finding:
 
 Therefore, @honda2014 created the notion of an Optimum Temperature (OT), at which the mortality is the lowest. Figure \@ref(fig:mortalityhondastrobl) shows an example for the Tokyo Prefecture and the period 1972-2008. A smoothing spline with six degrees of freedom was used to model the Relative Risk (RR) for mortality and observed daily maximum temperature data. OT represents the daily maximum temperature where RR is the lowest. RR was used here in order to account for different populations of regions and an RR=1.0 is the reference mortality at around OT, i.e. the average number of deaths observed when the daily maximum temperature was within the range of the 75th to the 85th percentile for each year.
 
-```{r mortalityhondastrobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="A smoothing spline with six degrees of freedom was used for temperature data from the Tokyo Prefecture and the period 1972-2008, showing the daily maximum temperatures and the Relative Risk (RR) for mortality."}
+```{r mortalityhondastrobl, cache=FALSE, out.width = "50%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="A smoothing spline with six degrees of freedom was used for temperature data from the Tokyo Prefecture and the period 1972-2008, showing the daily maximum temperatures and the Relative Risk (RR) for mortality."}
 knitr::include_graphics("work/08-lancet/figures/121_3.png")
 ```
 
@@ -102,16 +102,16 @@ The shaded area to the right of OT represents temperatures with increased mortal
 
 Figure \@ref(fig:mortality1strobl) shows the increase in the number of days with unsafe temperatures (daily maximum temperatures exceeding OT). This includes the increasing number of days that were made at least twice as likely due to human induced climate change (it is not described how the red line was created).
 
-```{r mortality1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Average number of days with unsafe temperatures for older adults from 1997 to 2022, including days that are twice as likely due to climate change."}
+```{r mortality1strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Average number of days with unsafe temperatures for older adults from 1997 to 2022, including days that are twice as likely due to climate change."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_1.png")
 ```
 
 In addition, Figures \@ref(fig:mortality2ssp1strobl) and \@ref(fig:mortality2ssp3strobl) show the absolute projected increase in heat-related mortality per country for older adults at mid-century (2041-2060) compared to 1995-2014 as baseline, for SSP1 and SSP3, respectively. In both cases there is an increase, although it seems that the two scenarios, SSP1 and SSP3, have been flipped accidentially. In addition, only the absolute increase is shown, i.e. it is obvious that highly populated countries, such as India and China, have a very high increase compared to smaller countries. 
 
-```{r mortality2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r mortality2ssp1strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_4.png")
 ```
-```{r mortality2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r mortality2ssp3strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the absolute change in heat-related mortality for older adults per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_2_5.png")
 ```
 
@@ -129,16 +129,16 @@ Headline Finding:
 
 Figure \@ref(fig:food1strobl) shows world-wide predictions of the change in percentage points (using the previously mentioned model) for heatwaves and drought months for the period 2014-2021. As temperatures, number of heatwave days as well as number of drought months increase, more people are expected to experience severe or moderate food insecurity.
 
-```{r food1strobl, cache=FALSE, out.width="700", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Impact of extreme weather (heatwaves and droughts) on food insecurity from 2014-2021, based on survey data."}
+```{r food1strobl, cache=FALSE, out.width = "100%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Impact of extreme weather (heatwaves and droughts) on food insecurity from 2014-2021, based on survey data."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_1.png")
 ```
 
 Figures \@ref(fig:food2ssp1strobl) and \@ref(fig:food2ssp3strobl) show projections (SSP1 and SSP3, respectively) for the percentage point changes for both kinds of extreme weather combined for mid-century (2014-2060), compared to the baseline 1995-2014. For example for Somalia, this change ranges from 4.02 (SSP1) to 10.32 (SSP3).
 
-```{r food2ssp1strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r food2ssp1strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP1 (under 2 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_2.png")
 ```
-```{r food2ssp3strobl, cache=FALSE, out.width="500", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
+```{r food2ssp3strobl, cache=FALSE, out.width = "80%", fig.align="center", eval=TRUE, echo=FALSE, fig.cap="Projections of the impact of extreme weather on food inscurity per country for SSP3 (3.7 degree scenario) for mid-century (2041-2060) with baseline period 1995-2014."}
 knitr::include_graphics("work/08-lancet/figures/indicator_3_3.png")
 ```
 

--- a/book.bib
+++ b/book.bib
@@ -690,70 +690,20 @@ doi = {10.1162/neco.1997.9.8.1735}
   publisher={Cambridge University Press New York, NY, USA}
 }
 
-@article{Van_Daalen2024-ut,
-  title    = "The 2024 Europe report of the Lancet Countdown on health and
-              climate change: unprecedented warming demands unprecedented
-              action",
-  author   = "van Daalen, Kim R and Tonne, Cathryn and Semenza, Jan C and
-              Rockl{\"o}v, Joacim and Markandya, Anil and Dasandi, Niheer and
-              Jankin, Slava and Achebak, Hicham and Ballester, Joan and
-              Bechara, Hannah and Beck, Thessa M and Callaghan, Max W and
-              Carvalho, Bruno M and Chambers, Jonathan and Pradas, Marta Cirah
-              and Courtenay, Orin and Dasgupta, Shouro and Eckelman, Matthew J
-              and Farooq, Zia and Fransson, Peter and Gallo, Elisa and
-              Gasparyan, Olga and Gonzalez-Reviriego, Nube and Hamilton, Ian
-              and H{\"a}nninen, Risto and Hatfield, Charles and He, Kehan and
-              Kazmierczak, Aleksandra and Kendrovski, Vladimir and Kennard,
-              Harry and Kiesewetter, Gregor and Kouznetsov, Rostislav and
-              Kriit, Hedi Katre and Llabr{\'e}s-Brustenga, Alba and Lloyd,
-              Simon J and Batista, Mart{\'\i}n Lotto and Maia, Carla and
-              Martinez-Urtaza, Jaime and Mi, Zhifu and Mil{\`a}, Carles and
-              Minx, Jan C and Nieuwenhuijsen, Mark and Palamarchuk, Julia and
-              Pantera, Dafni Kalatzi and Quijal-Zamorano, Marcos and Rafaj,
-              Peter and Robinson, Elizabeth J Z and S{\'a}nchez-Valdivia, Nacho
-              and Scamman, Daniel and Schmoll, Oliver and Sewe, Maquins
-              Odhiambo and Sherman, Jodi D and Singh, Pratik and Sirotkina,
-              Elena and Sj{\"o}din, Henrik and Sofiev, Mikhail and
-              Solaraju-Murali, Balakrishnan and Springmann, Marco and Treskova,
-              Marina and Tri{\~n}anes, Joaquin and Vanuytrecht, Eline and
-              Wagner, Fabian and Walawender, Maria and Warnecke, Laura and
-              Zhang, Ran and Romanello, Marina and Ant{\'o}, Josep M and
-              Nilsson, Maria and Lowe, Rachel",
-  journal  = "Lancet Public Health",
-  volume   =  9,
-  number   =  7,
-  pages    = "e495--e522",
-  month    =  may,
-  year     =  2024,
-  address  = "England",
-  language = "en"
+@article{alahamad2023,
+author = {Barrak Alahmad  and Haitham Khraishah  and Dominic Royé  and Ana Maria Vicedo-Cabrera  and Yuming Guo  and Stefania I. Papatheodorou  and Souzana Achilleos  and Fiorella Acquaotta  and Ben Armstrong  and Michelle L. Bell  and Shih-Chun Pan  and Micheline de Sousa Zanotti Stagliorio Coelho  and Valentina Colistro  and Tran Ngoc Dang  and Do Van Dung  and Francesca K. De’ Donato  and Alireza Entezari  and Yue-Liang Leon Guo  and Masahiro Hashizume  and Yasushi Honda  and Ene Indermitte  and Carmen Íñiguez  and Jouni J.K. Jaakkola  and Ho Kim  and Eric Lavigne  and Whanhee Lee  and Shanshan Li  and Joana Madureira  and Fatemeh Mayvaneh  and Hans Orru  and Ala Overcenco  and Martina S. Ragettli  and Niilo R.I. Ryti  and Paulo Hilario Nascimento Saldiva  and Noah Scovronick  and Xerxes Seposo  and Francesco Sera  and Susana Pereira Silva  and Massimo Stafoggia  and Aurelio Tobias  and Eric Garshick  and Aaron S. Bernstein  and Antonella Zanobetti  and Joel Schwartz  and Antonio Gasparrini  and Petros Koutrakis },
+title = {Associations Between Extreme Temperatures and Cardiovascular Cause-Specific Mortality: Results From 27 Countries},
+journal = {Circulation},
+volume = {147},
+number = {1},
+pages = {35-46},
+year = {2023},
+doi = {10.1161/CIRCULATIONAHA.122.061832},
+url = {https://www.ahajournals.org/doi/abs/10.1161/CIRCULATIONAHA.122.061832},
+eprint = {https://www.ahajournals.org/doi/pdf/10.1161/CIRCULATIONAHA.122.061832}
 }
 
-
-@article{CAFIERO2018146,
-title = {Food security measurement in a global context: The food insecurity experience scale},
-journal = {Measurement},
-volume = {116},
-pages = {146-152},
-year = {2018},
-issn = {0263-2241},
-doi = {https://doi.org/10.1016/j.measurement.2017.10.065},
-url = {https://www.sciencedirect.com/science/article/pii/S0263224117307005},
-author = {Carlo Cafiero and Sara Viviani and Mark Nord},
-keywords = {Food security measurement, Rasch model, Scale equating, Sustainable development goals},
-abstract = {The ability of households and individuals to access food (one of the key aspects of 'food security') is an important welfare dimension that poses important challenges for objective measurement. This paper describes the Rasch model-based procedures developed to define the eight-item Food Insecurity Experience Scale (FIES) as a contribution towards the establishment of an indicator for global monitoring of food insecurity. Experiential food insecurity survey data, collected by FAO from nationally representative samples of the adult population, once every year in 2014, 2015 and 2016 from 153 countries or territories, are used to develop methods to estimate cross-country comparable prevalence rates of moderate and severe food insecurity. A Rasch model-based scale was estimated separately for each country and data were assessed for consistency with model assumptions. To ensure cross-country comparability, a procedure based on the median normalized severities of each of the eight FIES items was used to define a global reference scale, against which measures obtained in each country can be separately calibrated. Calibration is obtained by equating the mean and standard deviation of the severity parameters of the items that appear to be common between the national and the reference scale, and thus used as anchoring points for the metric. Data showed sufficient consistency with the Rasch model assumptions to produce reliable measures of the prevalence of food insecurity in each country. Calibration was possible using 4 or more items as anchoring points in 151 of 153 (98.7%) of the cases, and 6 or more items in the vast majority of them (121 cases). Concurrent validation of the estimates of prevalence of food insecurity at national level was obtained by comparing the FIES-based indicator with other established indicators of social (under) development. National prevalence rates of moderate-or-severe food insecurity obtained by FAO correlate well with the prevalence of undernourishment and with several widely used indicators of national income, health, and well-being. The proposed calibration method can be applied to other existing experience-based food security scales that use similar items, thus affording the possibility to use data collected with those instruments to produce internationally comparable measures of the prevalence of food insecurity. Pending broader adoption of the FIES or compatible experience-based food security scales worldwide, countries could choose to use the 2014–2016 results obtained using the data collected by FAO as the baseline to monitor progress towards Target 2.1 of the recently established 2030 Agenda for Sustainable Development.}
-}
-
-@misc{noauthor_2023-jt,
-  title     = "The state of food security and nutrition in the world 2023",
-  publisher = "FAO; IFAD; UNICEF; WFP; WHO;",
-  month     =  jul,
-  year      =  2023,
-  language  = "en"
-}
-
-
-@article{Armstrong2006-mv,
+@article{armstrong2006,
   title    = "Models for the relationship between ambient temperature and daily
               mortality",
   author   = "Armstrong, Ben",
@@ -795,8 +745,76 @@ abstract = {The ability of households and individuals to access food (one of the
   language = "en"
 }
 
+@article{briggs2021,
+title={Briggs 2021 A global downscaled age structure data set for assessing human impacts of climate change, 1970-2100}, 
+url={http://rgdoi.net/10.13140/RG.2.2.32206.38723}, 
+DOI={10.13140/RG.2.2.32206.38723},
+author={Briggs, David John}, 
+year={2021}
+}
 
-@article{Honda2014,
+@article{cafiero2018,
+title = {Food security measurement in a global context: The food insecurity experience scale},
+journal = {Measurement},
+volume = {116},
+pages = {146-152},
+year = {2018},
+issn = {0263-2241},
+doi = {https://doi.org/10.1016/j.measurement.2017.10.065},
+url = {https://www.sciencedirect.com/science/article/pii/S0263224117307005},
+author = {Carlo Cafiero and Sara Viviani and Mark Nord}
+}
+
+@article{chambers2020a,
+author = {Chambers, Jonathan},
+year = {2020},
+month = {11},
+title = {Global and cross-country analysis of exposure of vulnerable populations to heatwaves from 1980 to 2018},
+journal = {Climatic Change},
+doi = {10.1007/s10584-020-02884-2}
+}
+
+@misc{chambers2020b, 
+title = {Hybrid gridded demographic data for the world, 1950-2020}, 
+DOI = {10.5281/zenodo.3768002}, 
+publisher = {Zenodo}, 
+author = {Chambers, Jonathan},
+year = {2020},
+}
+
+@article{eyring2016,
+author = {Eyring, V. and Bony, S. and Meehl, G. A. and Senior, C. A. and Stevens, B. and Stouffer, R. J. and Taylor, K. E.},
+title = {Overview of the Coupled Model Intercomparison Project Phase 6 (CMIP6)
+experimental design and organization},
+journal = {Geoscientific Model Development},
+volume = {9},
+year = {2016},
+number = {5},
+pages = {1937--1958},
+url = {https://gmd.copernicus.org/articles/9/1937/2016/},
+doi = {10.5194/gmd-9-1937-2016}
+}
+
+@misc{fao2023,
+  title     = {The state of food security and nutrition in the world 2023},
+  author = {FAO and IFAD and UNICEF and WFP and WHO},
+  month     =  {jul},
+  year      =  {2023},
+  language  = {en}
+}
+
+@article{hersbach2020,
+  title={The ERA5 global reanalysis},
+  author={Hersbach, Hans and Bell, Bill and Berrisford, Paul and Hirahara, Shoji and Hor{\'a}nyi, Andr{\'a}s and Mu{\~n}oz-Sabater, Joaqu{\'\i}n and Nicolas, Julien and Peubey, Carole and Radu, Raluca and Schepers, Dinand and others},
+  journal={Quarterly Journal of the Royal Meteorological Society},
+  volume={146},
+  number={730},
+  pages={1999--2049},
+  year={2020},
+  publisher={Wiley Online Library}
+}
+
+@article{honda2014,
 author={Honda, Yasushi
 and Kondo, Masahide
 and McGregor, Glenn
@@ -822,66 +840,14 @@ doi={10.1007/s12199-013-0354-6},
 url={https://doi.org/10.1007/s12199-013-0354-6}
 }
 
-@article{briggsdaviddownscaled,title={Briggs 2021 A global downscaled age structure data set for assessing human impacts of climate change, 1970-2100}, url={http://rgdoi.net/10.13140/RG.2.2.32206.38723}, DOI={10.13140/RG.2.2.32206.38723}, journal={Unpublished}, publisher={Unpublished}, author={Briggs, David John}, year={2021}, language={en} }
-
-@misc{Chambers_2020, title={Hybrid gridded demographic data for the world, 1950-2020}, DOI={10.5281/zenodo.3768002}, publisher={Zenodo}, author={Chambers, Jonathan}, year={2020} }
-
-@article{hersbach2020era5,
-  title={The ERA5 global reanalysis},
-  author={Hersbach, Hans and Bell, Bill and Berrisford, Paul and Hirahara, Shoji and Hor{\'a}nyi, Andr{\'a}s and Mu{\~n}oz-Sabater, Joaqu{\'\i}n and Nicolas, Julien and Peubey, Carole and Radu, Raluca and Schepers, Dinand and others},
-  journal={Quarterly Journal of the Royal Meteorological Society},
-  volume={146},
-  number={730},
-  pages={1999--2049},
-  year={2020},
-  publisher={Wiley Online Library}
-}
-
-@article{lange2021isimip3b,
+@article{lange2021,
   title={ISIMIP3b bias adjustment fact sheet},
   author={Lange, Stefan},
   journal={Potsdam: Inter-Sectoral Impact Model Intercomparison Project},
   year={2021}
 }
 
-@article{chambers2020,
-author = {Chambers, Jonathan},
-year = {2020},
-month = {11},
-pages = {},
-title = {Global and cross-country analysis of exposure of vulnerable populations to heatwaves from 1980 to 2018},
-journal = {Climatic Change},
-doi = {10.1007/s10584-020-02884-2}
-}
-
-@article{
-doi:10.1161/CIRCULATIONAHA.122.061832,
-author = {Barrak Alahmad  and Haitham Khraishah  and Dominic Royé  and Ana Maria Vicedo-Cabrera  and Yuming Guo  and Stefania I. Papatheodorou  and Souzana Achilleos  and Fiorella Acquaotta  and Ben Armstrong  and Michelle L. Bell  and Shih-Chun Pan  and Micheline de Sousa Zanotti Stagliorio Coelho  and Valentina Colistro  and Tran Ngoc Dang  and Do Van Dung  and Francesca K. De’ Donato  and Alireza Entezari  and Yue-Liang Leon Guo  and Masahiro Hashizume  and Yasushi Honda  and Ene Indermitte  and Carmen Íñiguez  and Jouni J.K. Jaakkola  and Ho Kim  and Eric Lavigne  and Whanhee Lee  and Shanshan Li  and Joana Madureira  and Fatemeh Mayvaneh  and Hans Orru  and Ala Overcenco  and Martina S. Ragettli  and Niilo R.I. Ryti  and Paulo Hilario Nascimento Saldiva  and Noah Scovronick  and Xerxes Seposo  and Francesco Sera  and Susana Pereira Silva  and Massimo Stafoggia  and Aurelio Tobias  and Eric Garshick  and Aaron S. Bernstein  and Antonella Zanobetti  and Joel Schwartz  and Antonio Gasparrini  and Petros Koutrakis },
-title = {Associations Between Extreme Temperatures and Cardiovascular Cause-Specific Mortality: Results From 27 Countries},
-journal = {Circulation},
-volume = {147},
-number = {1},
-pages = {35-46},
-year = {2023},
-doi = {10.1161/CIRCULATIONAHA.122.061832},
-URL = {https://www.ahajournals.org/doi/abs/10.1161/CIRCULATIONAHA.122.061832},
-eprint = {https://www.ahajournals.org/doi/pdf/10.1161/CIRCULATIONAHA.122.061832}}
-
-
-@Article{gmd-9-1937-2016,
-AUTHOR = {Eyring, V. and Bony, S. and Meehl, G. A. and Senior, C. A. and Stevens, B. and Stouffer, R. J. and Taylor, K. E.},
-TITLE = {Overview of the Coupled Model Intercomparison Project Phase 6 (CMIP6)
-experimental design and organization},
-JOURNAL = {Geoscientific Model Development},
-VOLUME = {9},
-YEAR = {2016},
-NUMBER = {5},
-PAGES = {1937--1958},
-URL = {https://gmd.copernicus.org/articles/9/1937/2016/},
-DOI = {10.5194/gmd-9-1937-2016}
-}
-
-@article{RIAHI2017153,
+@article{riahi2017,
 title = {The Shared Socioeconomic Pathways and their energy, land use, and greenhouse gas emissions implications: An overview},
 journal = {Global Environmental Change},
 volume = {42},
@@ -895,7 +861,7 @@ keywords = {Shared Socioeconomic Pathways, SSP, Climate change, RCP, Community s
 abstract = {This paper presents the overview of the Shared Socioeconomic Pathways (SSPs) and their energy, land use, and emissions implications. The SSPs are part of a new scenario framework, established by the climate change research community in order to facilitate the integrated analysis of future climate impacts, vulnerabilities, adaptation, and mitigation. The pathways were developed over the last years as a joint community effort and describe plausible major global developments that together would lead in the future to different challenges for mitigation and adaptation to climate change. The SSPs are based on five narratives describing alternative socio-economic developments, including sustainable development, regional rivalry, inequality, fossil-fueled development, and middle-of-the-road development. The long-term demographic and economic projections of the SSPs depict a wide uncertainty range consistent with the scenario literature. A multi-model approach was used for the elaboration of the energy, land-use and the emissions trajectories of SSP-based scenarios. The baseline scenarios lead to global energy consumption of 400–1200 EJ in 2100, and feature vastly different land-use dynamics, ranging from a possible reduction in cropland area up to a massive expansion by more than 700 million hectares by 2100. The associated annual CO2 emissions of the baseline scenarios range from about 25 GtCO2 to more than 120 GtCO2 per year by 2100. With respect to mitigation, we find that associated costs strongly depend on three factors: (1) the policy assumptions, (2) the socio-economic narrative, and (3) the stringency of the target. The carbon price for reaching the target of 2.6W/m2 that is consistent with a temperature change limit of 2°C, differs in our analysis thus by about a factor of three across the SSP marker scenarios. Moreover, many models could not reach this target from the SSPs with high mitigation challenges. While the SSPs were designed to represent different mitigation and adaptation challenges, the resulting narratives and quantifications span a wide range of different futures broadly representative of the current literature. This allows their subsequent use and development in new assessments and research projects. Critical next steps for the community scenario process will, among others, involve regional and sectoral extensions, further elaboration of the adaptation and impacts dimension, as well as employing the SSP scenarios with the new generation of earth system models as part of the 6th climate model intercomparison project (CMIP6).}
 }
 
-@article{romanello20232023,
+@article{romanello2023,
   title={The 2023 report of the Lancet Countdown on health and climate change: the imperative for a health-centred response in a world facing irreversible harms},
   author={Romanello, Marina and Di Napoli, Claudia and Green, Carole and Kennard, Harry and Lampard, Pete and Scamman, Daniel and Walawender, Maria and Ali, Zakari and Ameli, Nadia and Ayeb-Karlsson, Sonja and others},
   journal={The Lancet},
@@ -904,6 +870,45 @@ abstract = {This paper presents the overview of the Shared Socioeconomic Pathway
   pages={2346--2394},
   year={2023},
   publisher={Elsevier}
+}
+
+@article{vandaalen2024,
+  title    = "The 2024 Europe report of the Lancet Countdown on health and
+              climate change: unprecedented warming demands unprecedented
+              action",
+  author   = "van Daalen, Kim R and Tonne, Cathryn and Semenza, Jan C and
+              Rockl{\"o}v, Joacim and Markandya, Anil and Dasandi, Niheer and
+              Jankin, Slava and Achebak, Hicham and Ballester, Joan and
+              Bechara, Hannah and Beck, Thessa M and Callaghan, Max W and
+              Carvalho, Bruno M and Chambers, Jonathan and Pradas, Marta Cirah
+              and Courtenay, Orin and Dasgupta, Shouro and Eckelman, Matthew J
+              and Farooq, Zia and Fransson, Peter and Gallo, Elisa and
+              Gasparyan, Olga and Gonzalez-Reviriego, Nube and Hamilton, Ian
+              and H{\"a}nninen, Risto and Hatfield, Charles and He, Kehan and
+              Kazmierczak, Aleksandra and Kendrovski, Vladimir and Kennard,
+              Harry and Kiesewetter, Gregor and Kouznetsov, Rostislav and
+              Kriit, Hedi Katre and Llabr{\'e}s-Brustenga, Alba and Lloyd,
+              Simon J and Batista, Mart{\'\i}n Lotto and Maia, Carla and
+              Martinez-Urtaza, Jaime and Mi, Zhifu and Mil{\`a}, Carles and
+              Minx, Jan C and Nieuwenhuijsen, Mark and Palamarchuk, Julia and
+              Pantera, Dafni Kalatzi and Quijal-Zamorano, Marcos and Rafaj,
+              Peter and Robinson, Elizabeth J Z and S{\'a}nchez-Valdivia, Nacho
+              and Scamman, Daniel and Schmoll, Oliver and Sewe, Maquins
+              Odhiambo and Sherman, Jodi D and Singh, Pratik and Sirotkina,
+              Elena and Sj{\"o}din, Henrik and Sofiev, Mikhail and
+              Solaraju-Murali, Balakrishnan and Springmann, Marco and Treskova,
+              Marina and Tri{\~n}anes, Joaquin and Vanuytrecht, Eline and
+              Wagner, Fabian and Walawender, Maria and Warnecke, Laura and
+              Zhang, Ran and Romanello, Marina and Ant{\'o}, Josep M and
+              Nilsson, Maria and Lowe, Rachel",
+  journal  = "Lancet Public Health",
+  volume   =  9,
+  number   =  7,
+  pages    = "e495--e522",
+  month    =  may,
+  year     =  2024,
+  address  = "England",
+  language = "en"
 }
 
 @article{armstrong,

--- a/book.bib
+++ b/book.bib
@@ -746,7 +746,7 @@ eprint = {https://www.ahajournals.org/doi/pdf/10.1161/CIRCULATIONAHA.122.061832}
 }
 
 @article{briggs2021,
-title={Briggs 2021 A global downscaled age structure data set for assessing human impacts of climate change, 1970-2100}, 
+title={A global downscaled age structure data set for assessing human impacts of climate change, 1970-2100}, 
 url={http://rgdoi.net/10.13140/RG.2.2.32206.38723}, 
 DOI={10.13140/RG.2.2.32206.38723},
 author={Briggs, David John}, 
@@ -805,7 +805,7 @@ doi = {10.5194/gmd-9-1937-2016}
 
 @article{hersbach2020,
   title={The ERA5 global reanalysis},
-  author={Hersbach, Hans and Bell, Bill and Berrisford, Paul and Hirahara, Shoji and Hor{\'a}nyi, Andr{\'a}s and Mu{\~n}oz-Sabater, Joaqu{\'\i}n and Nicolas, Julien and Peubey, Carole and Radu, Raluca and Schepers, Dinand and others},
+  author={Hersbach, Hans and Bell, Bill and Berrisford, Paul and Hirahara, Shoji and Horanyi, Andras and Munoz-Sabater, Joaquin and Nicolas, Julien and Peubey, Carole and Radu, Raluca and Schepers, Dinand and others},
   journal={Quarterly Journal of the Royal Meteorological Society},
   volume={146},
   number={730},
@@ -859,17 +859,6 @@ url = {https://www.sciencedirect.com/science/article/pii/S0959378016300681},
 author = {Keywan Riahi and Detlef P. {van Vuuren} and Elmar Kriegler and Jae Edmonds and Brian C. O’Neill and Shinichiro Fujimori and Nico Bauer and Katherine Calvin and Rob Dellink and Oliver Fricko and Wolfgang Lutz and Alexander Popp and Jesus Crespo Cuaresma and Samir KC and Marian Leimbach and Leiwen Jiang and Tom Kram and Shilpa Rao and Johannes Emmerling and Kristie Ebi and Tomoko Hasegawa and Petr Havlik and Florian Humpenöder and Lara Aleluia {Da Silva} and Steve Smith and Elke Stehfest and Valentina Bosetti and Jiyong Eom and David Gernaat and Toshihiko Masui and Joeri Rogelj and Jessica Strefler and Laurent Drouet and Volker Krey and Gunnar Luderer and Mathijs Harmsen and Kiyoshi Takahashi and Lavinia Baumstark and Jonathan C. Doelman and Mikiko Kainuma and Zbigniew Klimont and Giacomo Marangoni and Hermann Lotze-Campen and Michael Obersteiner and Andrzej Tabeau and Massimo Tavoni},
 keywords = {Shared Socioeconomic Pathways, SSP, Climate change, RCP, Community scenarios, Mitigation, Adaptation},
 abstract = {This paper presents the overview of the Shared Socioeconomic Pathways (SSPs) and their energy, land use, and emissions implications. The SSPs are part of a new scenario framework, established by the climate change research community in order to facilitate the integrated analysis of future climate impacts, vulnerabilities, adaptation, and mitigation. The pathways were developed over the last years as a joint community effort and describe plausible major global developments that together would lead in the future to different challenges for mitigation and adaptation to climate change. The SSPs are based on five narratives describing alternative socio-economic developments, including sustainable development, regional rivalry, inequality, fossil-fueled development, and middle-of-the-road development. The long-term demographic and economic projections of the SSPs depict a wide uncertainty range consistent with the scenario literature. A multi-model approach was used for the elaboration of the energy, land-use and the emissions trajectories of SSP-based scenarios. The baseline scenarios lead to global energy consumption of 400–1200 EJ in 2100, and feature vastly different land-use dynamics, ranging from a possible reduction in cropland area up to a massive expansion by more than 700 million hectares by 2100. The associated annual CO2 emissions of the baseline scenarios range from about 25 GtCO2 to more than 120 GtCO2 per year by 2100. With respect to mitigation, we find that associated costs strongly depend on three factors: (1) the policy assumptions, (2) the socio-economic narrative, and (3) the stringency of the target. The carbon price for reaching the target of 2.6W/m2 that is consistent with a temperature change limit of 2°C, differs in our analysis thus by about a factor of three across the SSP marker scenarios. Moreover, many models could not reach this target from the SSPs with high mitigation challenges. While the SSPs were designed to represent different mitigation and adaptation challenges, the resulting narratives and quantifications span a wide range of different futures broadly representative of the current literature. This allows their subsequent use and development in new assessments and research projects. Critical next steps for the community scenario process will, among others, involve regional and sectoral extensions, further elaboration of the adaptation and impacts dimension, as well as employing the SSP scenarios with the new generation of earth system models as part of the 6th climate model intercomparison project (CMIP6).}
-}
-
-@article{romanello2023,
-  title={The 2023 report of the Lancet Countdown on health and climate change: the imperative for a health-centred response in a world facing irreversible harms},
-  author={Romanello, Marina and Di Napoli, Claudia and Green, Carole and Kennard, Harry and Lampard, Pete and Scamman, Daniel and Walawender, Maria and Ali, Zakari and Ameli, Nadia and Ayeb-Karlsson, Sonja and others},
-  journal={The Lancet},
-  volume={402},
-  number={10419},
-  pages={2346--2394},
-  year={2023},
-  publisher={Elsevier}
 }
 
 @article{vandaalen2024,


### PR DESCRIPTION
These are my final fixes. I tested both, html and pdf, and there is one warning I cannot get rid of. One of my cited articles (Briggs 2021) has a missing journal, but I don't think it was published in a journal anyways. This is taken from the Lancet data platform, cited with one of the indicators I presented.

I did not sort the whole bibtex file, just my own citations. Not sure if there is a workaround, but it is very tedious if we all work on the same file, seeing everybodys warnings etc.